### PR TITLE
Support objection v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 
 node_js:
   - "8"
-  - "9"
-  - "11"
+  - "10"
+  - "12"
   - "node"
 
 after_script: "npm run coveralls"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018 Pixul and project contributors
+Copyright (c) 2016-2019 Pixul and project contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "db-errors": "0.2.x"
   },
   "devDependencies": {
-    "objection": "1.x.x",
+    "objection": "2.x.x",
     "coveralls": "3.x.x",
     "@hapi/code": "6.x.x",
     "@hapi/lab": "20.x.x"
   },
   "peerDependencies": {
-    "objection": "1.x.x"
+    "objection": ">=1 <3"
   }
 }


### PR DESCRIPTION
As far as I can tell this already works great with objection v2, and it just needs to declare that as a peer dependency.  It's worth noting that db-errors is now used directly by objection, so issues could arise in the future if this module's db-errors dependency isn't identical to objection's.  With a breaking change this library could probably drop support for objection v1, remove the `wrapError()` call, and be less likely to get into dependency tangles.