### PR TITLE
Move to @hapipal scope, update docs for org-wide consistency

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,10 +1,59 @@
 # API
 
-#### `rethrow(error, [options])`
+A utility to convert [Objection](https://vincit.github.io/objection.js/) database errors into [Boom](https://hapi.dev/module/boom/) HTTP errors
 
-Throws a `Boom` error according to the `Objection` error received.
+> **Note**
+>
+> Avocat is intended for use with hapi v19+, nodejs v12+, and Objection v2 (_see v1 for lower support_).
 
- - `error` - the `Objection` error (any other types of errors are just ignored).
+## `Avocat`
+### `Avocat.rethrow(error, [options])`
+Throws a Boom error according to the Objection error received.
+
+ - `error` - the Objection error (any other types of errors are just ignored).
  - `options` - optional object where:
      - `return` - if `true` will return the error instead of throwing it.
-     - `includeMessage` - if `true` the Boom error created will have its message set to the message of the error thrown.
+     - `includeMessage` - if `true` the Boom error created will preserve the Objection error message.
+
+#### Error mappings
+
+These are the error mappings maintained by Avocat:
+
+ - `NotFoundError` → 404 Not Found
+ - `ValidationError` → 400 Bad Request
+ - `NotNullViolationError` → 400 Bad Request
+ - `ConstraintViolationError` → 400 Bad Request
+ - `ForeignKeyViolationError` → 400 Bad Request
+ - `DataError` → 400 Bad Request
+ - `CheckViolationError` → 400 Bad Request
+ - `UniqueViolationError` → 409 Conflict
+ - `DBError` → 500 Internal Server Error
+
+### Example
+
+```js
+'use strict';
+
+const Hapi = require('@hapi/hapi');
+const Avocat = require('@hapipal/avocat');
+const User = require('./user-model'); // An Objection model bound to a knex instance
+
+const server = Hapi.server();
+
+server.route({
+    method: 'get',
+    path: '/users/{id}',
+    handler(request) {
+
+        try {
+            return await User.query()
+                .findById(request.params.id)
+                .throwIfNotFound();
+        }
+        catch (err) {
+            Avocat.rethrow(err); // Throws a 404 Not Found if user does not exist
+            throw err;
+        }
+    }
+});
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2020 Pixul and project contributors
+Copyright (c) 2016-2021 Pixul and project contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,22 +1,49 @@
 # avocat
 
-A library to convert Objection errors to Boom errors
+A utility to convert [Objection](https://vincit.github.io/objection.js/) database errors into [Boom](https://hapi.dev/module/boom/) HTTP errors
 
-[![Build Status](https://travis-ci.org/hapipal/avocat.svg?branch=master)](https://travis-ci.org/hapipal/avocat) [![Coverage Status](https://coveralls.io/repos/github/hapipal/avocat/badge.svg?branch=master)](https://coveralls.io/github/hapipal/avocat?branch=master)
+[![Build Status](https://travis-ci.com/hapipal/avocat.svg?branch=master)](https://travis-ci.com/hapipal/avocat) [![Coverage Status](https://coveralls.io/repos/github/hapipal/avocat/badge.svg?branch=master)](https://coveralls.io/github/hapipal/avocat?branch=master)
 
 Lead Maintainer: [Daniel Cole](https://github.com/optii)
 
+## Installation
+```sh
+npm install @hapipal/avocat
+```
 
 ## Usage
+> See also the [API Reference](API.md)
+>
+> Avocat is intended for use with hapi v19+, nodejs v12+, and Objection v2 (_see v1 for lower support_).
 
-### `rethrow(error, [options])`
+Avocat provides a single utility function [`Avocat.throw(error, [options])`](API.md#avocatthrowerror-options) which transforms database errors from Objection into Boom HTTP errors that are compatible with hapi.
 
- Throws a `Boom` error according to the `Objection` error received
+```js
+'use strict';
 
- - `error`: - the `Objection` error (any other types of errors are just ignored)
- - `options`: - optional object where:
-     - `return`: - if `true` will return the error instead of throwing it
-     - `includeMessage`: if `true` the Boom error created will have it's message set to the message of the error thrown
+const Hapi = require('@hapi/hapi');
+const Avocat = require('@hapipal/avocat');
+const User = require('./user-model'); // An Objection model bound to a knex instance
 
+const server = Hapi.server();
 
-Heavily inspired by [Bounce](https://github.com/hapijs/bounce)
+server.route({
+    method: 'get',
+    path: '/users/{id}',
+    handler(request) {
+
+        try {
+            return await User.query()
+                .findById(request.params.id)
+                .throwIfNotFound();
+        }
+        catch (err) {
+            Avocat.rethrow(err); // Throws a 404 Not Found if user does not exist
+            throw err;
+        }
+    }
+});
+```
+
+## Extras
+The interface for Avocat is heavily inspired by [Bounce](https://hapi.dev/module/bounce/).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install @hapipal/avocat
 >
 > Avocat is intended for use with hapi v19+, nodejs v12+, and Objection v2 (_see v1 for lower support_).
 
-Avocat provides a single utility function [`Avocat.throw(error, [options])`](API.md#avocatthrowerror-options) which transforms database errors from Objection into Boom HTTP errors that are compatible with hapi.
+Avocat provides a single utility function [`Avocat.rethrow(error, [options])`](API.md#avocatrethrowerror-options) which transforms database errors from Objection into Boom HTTP errors that are compatible with hapi.
 
 ```js
 'use strict';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "avocat",
-  "description": "A simple library to convert objection errors to boom errors",
+  "name": "@hapipal/avocat",
+  "description": "A utility to convert Objection database errors into Boom HTTP errors",
   "version": "2.0.0",
   "main": "lib/index.js",
   "author": "Daniel COLE <daniel@pixul.fr>",


### PR DESCRIPTION
This resolves #7 by moving the package to the @hapipal npm scope.  This also includes some reorganization of the docs to be consistent with the doc formatting throughout the rest of the organization, including a new "installation" section to make the name of the npm module more clear.