### PR TITLE
Simplify logic for looking-up boom error type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,36 +1,33 @@
 'use strict';
 
-const { ValidationError, NotFoundError, DBError, ConstraintViolationError, UniqueViolationError, NotNullViolationError, ForeignKeyViolationError, CheckViolationError, DataError } = require('objection');
+const {
+    NotFoundError,
+    ValidationError,
+    NotNullViolationError,
+    ConstraintViolationError,
+    ForeignKeyViolationError,
+    DataError,
+    CheckViolationError,
+    UniqueViolationError,
+    DBError
+} = require('objection');
 const Boom = require('@hapi/boom');
 
 const internals = {
-    dbErrorMapping: {
-        notFound: [
-            NotFoundError
-        ],
-        badRequest: [
-            ValidationError,
-            NotNullViolationError,
-            ConstraintViolationError,
-            ForeignKeyViolationError,
-            DataError,
-            CheckViolationError
-        ],
-        conflict: [
-            UniqueViolationError
-        ],
-        internal: [
-            DBError
-        ]
-    }
+    dbErrorMapping: new Map([
+        [NotFoundError, 'notFound'],
+        [ValidationError, 'badRequest'],
+        [NotNullViolationError, 'badRequest'],
+        [ConstraintViolationError, 'badRequest'],
+        [ForeignKeyViolationError, 'badRequest'],
+        [DataError, 'badRequest'],
+        [CheckViolationError, 'badRequest'],
+        [UniqueViolationError, 'conflict'],
+        [DBError, 'internal']
+    ])
 };
 
 exports.rethrow = (error, options = {}) => {
-
-    return internals.catch(error, options);
-};
-
-internals.catch = (error, options) => {
 
     const err = internals.match(error, { includeMessage: options.includeMessage || false });
 
@@ -43,20 +40,15 @@ internals.catch = (error, options) => {
 
 internals.match = (error, options) => {
 
-    if (typeof error !== 'object') {
+    if (!error || typeof error !== 'object') {
         return false;
     }
 
-    for (const key in internals.dbErrorMapping) {
+    const type = internals.dbErrorMapping.get(error.constructor);
 
-        for (let i = 0; i < internals.dbErrorMapping[key].length; ++i) {
-
-            if (error instanceof internals.dbErrorMapping[key][i] && error.constructor.name === internals.dbErrorMapping[key][i].name) {
-
-                return Boom[key](options.includeMessage ? error.message : null);
-            }
-        }
+    if (!type) {
+        return false;
     }
 
-    return false;
+    return Boom[type](options.includeMessage ? error.message : null);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,17 @@ const lab              = exports.lab = Lab.script();
 const { describe, it } = lab;
 const { expect }       = Code;
 
-const { ValidationError, NotFoundError, UniqueViolationError, DBError, CheckViolationError, DataError, ForeignKeyViolationError, ConstraintViolationError, NotNullViolationError } = require('objection');
+const {
+    NotFoundError,
+    ValidationError,
+    NotNullViolationError,
+    ConstraintViolationError,
+    ForeignKeyViolationError,
+    DataError,
+    CheckViolationError,
+    UniqueViolationError,
+    DBError
+} = require('objection');
 
 const Avocat = require('../lib');
 
@@ -17,6 +27,8 @@ describe('Avocat', () => {
 
         it('should return false if not an error', () => {
 
+            expect(Avocat.rethrow(null, { return: true })).to.equal(false);
+            expect(Avocat.rethrow(null)).to.equal(false);
             expect(Avocat.rethrow('notanerror', { return: true })).to.equal(false);
             expect(Avocat.rethrow('notanerror')).to.equal(false);
         });


### PR DESCRIPTION
While working on #10 I noticed there there might be an opportunity to simplify some of the logic used to look-up a boom error type from an objection error type.

If I understand correctly this logic is looking for an exact constructor match:
```js
if (error instanceof internals.dbErrorMapping[key][i] && error.constructor.name === internals.dbErrorMapping[key][i].name) {
    return Boom[key](options.includeMessage ? error.message : null);
}
```

The idea here is to use a `Map` keyed by objection error classes to do a direct lookup on the error's constructor to see if it is of one of those classes.